### PR TITLE
Moved the TaskType enum to the API types project

### DIFF
--- a/src/SFA.DAS.Tasks.API.Types/Enums/TaskType.cs
+++ b/src/SFA.DAS.Tasks.API.Types/Enums/TaskType.cs
@@ -1,4 +1,4 @@
-﻿namespace SFA.DAS.Tasks.Domain.Enums
+﻿namespace SFA.DAS.Tasks.API.Types.Enums
 {
     public enum TaskType
     {

--- a/src/SFA.DAS.Tasks.API.Types/SFA.DAS.Tasks.API.Types.csproj
+++ b/src/SFA.DAS.Tasks.API.Types/SFA.DAS.Tasks.API.Types.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DTOs\TaskDto.cs" />
+    <Compile Include="Enums\TaskType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SFA.DAS.Tasks.API.UnitTests/Controllers/TaskControllerTests/WhenIGetTasks.cs
+++ b/src/SFA.DAS.Tasks.API.UnitTests/Controllers/TaskControllerTests/WhenIGetTasks.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using SFA.DAS.Tasks.Application.Queries.GetTasksByOwnerId;
 using SFA.DAS.Tasks.API.Controllers;
 using SFA.DAS.Tasks.API.Types.DTOs;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 using SFA.DAS.Tasks.Domain.Models;
 
 namespace SFA.DAS.Tasks.API.UnitTests.Controllers.TaskControllerTests

--- a/src/SFA.DAS.Tasks.Application.UnitTests/Commands/SaveTaskCommandTests/WhenISaveATask.cs
+++ b/src/SFA.DAS.Tasks.Application.UnitTests/Commands/SaveTaskCommandTests/WhenISaveATask.cs
@@ -4,7 +4,7 @@ using Moq;
 using NUnit.Framework;
 using SFA.DAS.Tasks.Application.Commands.SaveTask;
 using SFA.DAS.Tasks.Application.Validation;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 using SFA.DAS.Tasks.Domain.Models;
 using SFA.DAS.Tasks.Domain.Repositories;
 

--- a/src/SFA.DAS.Tasks.Application.UnitTests/Commands/SaveTaskCommandTests/WhenIValidateTheRequest.cs
+++ b/src/SFA.DAS.Tasks.Application.UnitTests/Commands/SaveTaskCommandTests/WhenIValidateTheRequest.cs
@@ -1,6 +1,6 @@
 ﻿using NUnit.Framework;
 using SFA.DAS.Tasks.Application.Commands.SaveTask;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.Application.UnitTests.Commands.SaveTaskCommandTests
 {

--- a/src/SFA.DAS.Tasks.Application.UnitTests/Queries/GetTaskTests/WhenIGetATask.cs
+++ b/src/SFA.DAS.Tasks.Application.UnitTests/Queries/GetTaskTests/WhenIGetATask.cs
@@ -3,7 +3,7 @@ using Moq;
 using NUnit.Framework;
 using SFA.DAS.Tasks.Application.Queries.GetTask;
 using SFA.DAS.Tasks.Application.Validation;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 using SFA.DAS.Tasks.Domain.Models;
 using SFA.DAS.Tasks.Domain.Repositories;
 

--- a/src/SFA.DAS.Tasks.Application.UnitTests/Queries/GetTaskTests/WhenIValidateTheRequest.cs
+++ b/src/SFA.DAS.Tasks.Application.UnitTests/Queries/GetTaskTests/WhenIValidateTheRequest.cs
@@ -1,6 +1,6 @@
 ﻿using NUnit.Framework;
 using SFA.DAS.Tasks.Application.Queries.GetTask;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.Application.UnitTests.Queries.GetTaskTests
 {

--- a/src/SFA.DAS.Tasks.Application.UnitTests/SFA.DAS.Tasks.Application.UnitTests.csproj
+++ b/src/SFA.DAS.Tasks.Application.UnitTests/SFA.DAS.Tasks.Application.UnitTests.csproj
@@ -67,6 +67,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.Tasks.API.Types\SFA.DAS.Tasks.API.Types.csproj">
+      <Project>{0FA10E00-F9B9-433A-AAC0-FEE0E4EF179A}</Project>
+      <Name>SFA.DAS.Tasks.API.Types</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SFA.DAS.Tasks.Application\SFA.DAS.Tasks.Application.csproj">
       <Project>{B96FB4DB-3DCE-4D4A-B7F1-EDE97233B177}</Project>
       <Name>SFA.DAS.Tasks.Application</Name>

--- a/src/SFA.DAS.Tasks.Application/Commands/SaveTask/SaveTaskCommand.cs
+++ b/src/SFA.DAS.Tasks.Application/Commands/SaveTask/SaveTaskCommand.cs
@@ -1,5 +1,5 @@
 ﻿using MediatR;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.Application.Commands.SaveTask
 {

--- a/src/SFA.DAS.Tasks.Application/Commands/SaveTask/SaveTaskCommandHandler.cs
+++ b/src/SFA.DAS.Tasks.Application/Commands/SaveTask/SaveTaskCommandHandler.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using MediatR;
 using SFA.DAS.Tasks.Application.Exceptions;
 using SFA.DAS.Tasks.Application.Validation;
-using SFA.DAS.Tasks.Domain.Enums;
 using SFA.DAS.Tasks.Domain.Models;
 using SFA.DAS.Tasks.Domain.Repositories;
 

--- a/src/SFA.DAS.Tasks.Application/Commands/SaveTask/SaveTaskCommandValidator.cs
+++ b/src/SFA.DAS.Tasks.Application/Commands/SaveTask/SaveTaskCommandValidator.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using SFA.DAS.Tasks.Application.Validation;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.Application.Commands.SaveTask
 {

--- a/src/SFA.DAS.Tasks.Application/Queries/GetTask/GetTaskRequest.cs
+++ b/src/SFA.DAS.Tasks.Application/Queries/GetTask/GetTaskRequest.cs
@@ -1,5 +1,5 @@
 ﻿using MediatR;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.Application.Queries.GetTask
 {

--- a/src/SFA.DAS.Tasks.Application/Queries/GetTask/GetTaskRequestValidator.cs
+++ b/src/SFA.DAS.Tasks.Application/Queries/GetTask/GetTaskRequestValidator.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using SFA.DAS.Tasks.Application.Validation;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.Application.Queries.GetTask
 {

--- a/src/SFA.DAS.Tasks.Application/SFA.DAS.Tasks.Application.csproj
+++ b/src/SFA.DAS.Tasks.Application/SFA.DAS.Tasks.Application.csproj
@@ -68,6 +68,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.Tasks.API.Types\SFA.DAS.Tasks.API.Types.csproj">
+      <Project>{0FA10E00-F9B9-433A-AAC0-FEE0E4EF179A}</Project>
+      <Name>SFA.DAS.Tasks.API.Types</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SFA.DAS.Tasks.Domain\SFA.DAS.Tasks.Domain.csproj">
       <Project>{316591ff-d233-4529-bc3b-fa6b79c2db11}</Project>
       <Name>SFA.DAS.Tasks.Domain</Name>

--- a/src/SFA.DAS.Tasks.DataAccess/Repositories/TaskRepository.cs
+++ b/src/SFA.DAS.Tasks.DataAccess/Repositories/TaskRepository.cs
@@ -4,8 +4,8 @@ using System.Threading.Tasks;
 using Dapper;
 using SFA.DAS.NLog.Logger;
 using SFA.DAS.Sql.Client;
+using SFA.DAS.Tasks.API.Types.Enums;
 using SFA.DAS.Tasks.Domain.Configurations;
-using SFA.DAS.Tasks.Domain.Enums;
 using SFA.DAS.Tasks.Domain.Models;
 using SFA.DAS.Tasks.Domain.Repositories;
 

--- a/src/SFA.DAS.Tasks.DataAccess/SFA.DAS.Tasks.DataAccess.csproj
+++ b/src/SFA.DAS.Tasks.DataAccess/SFA.DAS.Tasks.DataAccess.csproj
@@ -67,6 +67,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.Tasks.API.Types\SFA.DAS.Tasks.API.Types.csproj">
+      <Project>{0FA10E00-F9B9-433A-AAC0-FEE0E4EF179A}</Project>
+      <Name>SFA.DAS.Tasks.API.Types</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SFA.DAS.Tasks.Domain\SFA.DAS.Tasks.Domain.csproj">
       <Project>{316591FF-D233-4529-BC3B-FA6B79C2DB11}</Project>
       <Name>SFA.DAS.Tasks.Domain</Name>

--- a/src/SFA.DAS.Tasks.Domain/Models/DasTask.cs
+++ b/src/SFA.DAS.Tasks.Domain/Models/DasTask.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.Domain.Models
 {

--- a/src/SFA.DAS.Tasks.Domain/Repositories/ITaskRepository.cs
+++ b/src/SFA.DAS.Tasks.Domain/Repositories/ITaskRepository.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 using SFA.DAS.Tasks.Domain.Models;
 
 namespace SFA.DAS.Tasks.Domain.Repositories

--- a/src/SFA.DAS.Tasks.Domain/SFA.DAS.Tasks.Domain.csproj
+++ b/src/SFA.DAS.Tasks.Domain/SFA.DAS.Tasks.Domain.csproj
@@ -48,7 +48,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Configurations\TasksConfiguration.cs" />
-    <Compile Include="Enums\TaskType.cs" />
     <Compile Include="Models\DasTask.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repositories\ITaskRepository.cs" />
@@ -56,6 +55,12 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.Tasks.API.Types\SFA.DAS.Tasks.API.Types.csproj">
+      <Project>{0FA10E00-F9B9-433A-AAC0-FEE0E4EF179A}</Project>
+      <Name>SFA.DAS.Tasks.API.Types</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/SFA.DAS.Tasks.Worker.UnitTests/MessageProcessors/CreatedEmployerAgreementMessageProcessorTests/WhenIProcessAMessage.cs
+++ b/src/SFA.DAS.Tasks.Worker.UnitTests/MessageProcessors/CreatedEmployerAgreementMessageProcessorTests/WhenIProcessAMessage.cs
@@ -8,7 +8,7 @@ using SFA.DAS.Messaging;
 using SFA.DAS.Messaging.FileSystem;
 using SFA.DAS.NLog.Logger;
 using SFA.DAS.Tasks.Application.Commands.SaveTask;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 using SFA.DAS.Tasks.Worker.MessageProcessors;
 
 namespace SFA.DAS.Tasks.Worker.UnitTests.MessageProcessors.CreatedEmployerAgreementMessageProcessorTests

--- a/src/SFA.DAS.Tasks.Worker.UnitTests/SFA.DAS.Tasks.Worker.UnitTests.csproj
+++ b/src/SFA.DAS.Tasks.Worker.UnitTests/SFA.DAS.Tasks.Worker.UnitTests.csproj
@@ -76,6 +76,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.Tasks.API.Types\SFA.DAS.Tasks.API.Types.csproj">
+      <Project>{0FA10E00-F9B9-433A-AAC0-FEE0E4EF179A}</Project>
+      <Name>SFA.DAS.Tasks.API.Types</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SFA.DAS.Tasks.Application\SFA.DAS.Tasks.Application.csproj">
       <Project>{B96FB4DB-3DCE-4D4A-B7F1-EDE97233B177}</Project>
       <Name>SFA.DAS.Tasks.Application</Name>

--- a/src/SFA.DAS.Tasks.Worker/MessageProcessors/CreatedEmployerAgreementMessageProcessor.cs
+++ b/src/SFA.DAS.Tasks.Worker/MessageProcessors/CreatedEmployerAgreementMessageProcessor.cs
@@ -4,7 +4,7 @@ using SFA.DAS.EmployerAccounts.Events.Messages;
 using SFA.DAS.Messaging;
 using SFA.DAS.NLog.Logger;
 using SFA.DAS.Tasks.Application.Commands.SaveTask;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.Worker.MessageProcessors
 {

--- a/src/SFA.DAS.Tasks.Worker/MessageProcessors/SignedEmployerAgreementMessageProcessor.cs
+++ b/src/SFA.DAS.Tasks.Worker/MessageProcessors/SignedEmployerAgreementMessageProcessor.cs
@@ -4,7 +4,7 @@ using SFA.DAS.EmployerAccounts.Events.Messages;
 using SFA.DAS.Messaging;
 using SFA.DAS.NLog.Logger;
 using SFA.DAS.Tasks.Application.Commands.SaveTask;
-using SFA.DAS.Tasks.Domain.Enums;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.Worker.MessageProcessors
 {

--- a/src/SFA.DAS.Tasks.Worker/SFA.DAS.Tasks.Worker.csproj
+++ b/src/SFA.DAS.Tasks.Worker/SFA.DAS.Tasks.Worker.csproj
@@ -122,6 +122,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\SFA.DAS.Tasks.API.Types\SFA.DAS.Tasks.API.Types.csproj">
+      <Project>{0FA10E00-F9B9-433A-AAC0-FEE0E4EF179A}</Project>
+      <Name>SFA.DAS.Tasks.API.Types</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SFA.DAS.Tasks.Application\SFA.DAS.Tasks.Application.csproj">
       <Project>{B96FB4DB-3DCE-4D4A-B7F1-EDE97233B177}</Project>
       <Name>SFA.DAS.Tasks.Application</Name>


### PR DESCRIPTION
- This means the enum can be shared with external projects. We could have created an external version of the enum with the same values but the benefits of this seemed little as external projects will always need to know the same details as the internal code with regards to task types