### PR TITLE
Implemented the remove legal entity processor

### DIFF
--- a/src/SFA.DAS.Tasks.Worker.UnitTests/MessageProcessors/LegalEntityRemovedMessageProcessorTests/WhenIRemoveALegalEntity.cs
+++ b/src/SFA.DAS.Tasks.Worker.UnitTests/MessageProcessors/LegalEntityRemovedMessageProcessorTests/WhenIRemoveALegalEntity.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.EmployerAccounts.Events.Messages;
+using SFA.DAS.Messaging.Interfaces;
+using SFA.DAS.NLog.Logger;
+using SFA.DAS.Tasks.Application.Commands.SaveTask;
+using SFA.DAS.Tasks.API.Types.Enums;
+using SFA.DAS.Tasks.Worker.MessageProcessors;
+
+namespace SFA.DAS.Tasks.Worker.UnitTests.MessageProcessors.LegalEntityRemovedMessageProcessorTests
+{
+    public class WhenIRemoveALegalEntity
+    {
+        private Mock<IMessageSubscriberFactory> _subscriberFactory;
+        private LegalEntityRemovedMessageProcessor _processor;
+        private Mock<ILog> _logger;
+        private Mock<IMediator> _mediator;
+        private Mock<IMessageSubscriber<LegalEntityRemovedMessage>> _subscriber;
+        private CancellationTokenSource _cancellationTokenSource;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _subscriberFactory = new Mock<IMessageSubscriberFactory>();
+            _subscriber = new Mock<IMessageSubscriber<LegalEntityRemovedMessage>>();
+            _logger = new Mock<ILog>();
+            _mediator = new Mock<IMediator>();
+            _cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            _subscriberFactory.Setup(x => x.GetSubscriber<LegalEntityRemovedMessage>())
+                .Returns(_subscriber.Object);
+
+            _processor = new LegalEntityRemovedMessageProcessor(_subscriberFactory.Object, _logger.Object, _mediator.Object);
+        }
+
+        [Test]
+        public async Task ThenIfTheAgreementHasNotBeenSignedTheRelatedTaskIsRemoved()
+        {
+            //Arrange
+            const long accountId = 12L;
+            var message = new Mock<IMessage<LegalEntityRemovedMessage>>();
+
+            message.Setup(x => x.Content).Returns(new LegalEntityRemovedMessage
+            {
+                AccountId = accountId,
+                AgreementSigned = false
+            }).Callback(_cancellationTokenSource.Cancel);
+
+            _subscriber.Setup(x => x.ReceiveAsAsync()).ReturnsAsync(message.Object);
+
+            //Act
+            await _processor.RunAsync(_cancellationTokenSource.Token);
+
+            //Assert
+            _mediator.Verify(x => x.SendAsync(It.Is<SaveTaskCommand>(t => t.TaskCompleted && 
+                                                                          t.Type == TaskType.AgreementToSign &&
+                                                                          t.OwnerId.Equals(accountId.ToString()))), Times.Once);
+        }
+
+        [Test]
+        public async Task ThenIfTheAgreementHasBeenSignedNoRelatedTaskIsRemoved()
+        {
+            //Arrange
+            var message = new Mock<IMessage<LegalEntityRemovedMessage>>();
+
+            message.Setup(x => x.Content).Returns(new LegalEntityRemovedMessage
+            {
+                AgreementSigned = true
+            }).Callback(_cancellationTokenSource.Cancel);
+
+            _subscriber.Setup(x => x.ReceiveAsAsync()).ReturnsAsync(message.Object);
+
+            //Act
+            await _processor.RunAsync(_cancellationTokenSource.Token);
+
+            //Assert
+            _subscriber.Verify(x => x.ReceiveAsAsync(), Times.Once);
+            _mediator.Verify(x => x.SendAsync(It.IsAny<SaveTaskCommand>()), Times.Never);
+        }
+    }
+}

--- a/src/SFA.DAS.Tasks.Worker.UnitTests/SFA.DAS.Tasks.Worker.UnitTests.csproj
+++ b/src/SFA.DAS.Tasks.Worker.UnitTests/SFA.DAS.Tasks.Worker.UnitTests.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MessageProcessors\CreatedEmployerAgreementMessageProcessorTests\WhenIProcessAMessage.cs" />
+    <Compile Include="MessageProcessors\LegalEntityRemovedMessageProcessorTests\WhenIRemoveALegalEntity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SFA.DAS.Tasks.Worker/MessageProcessors/LegalEntityRemovedMessageProcessor.cs
+++ b/src/SFA.DAS.Tasks.Worker/MessageProcessors/LegalEntityRemovedMessageProcessor.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading.Tasks;
+using MediatR;
+using SFA.DAS.EmployerAccounts.Events.Messages;
+using SFA.DAS.Messaging;
+using SFA.DAS.Messaging.AzureServiceBus.Attributes;
+using SFA.DAS.Messaging.Interfaces;
+using SFA.DAS.NLog.Logger;
+using SFA.DAS.Tasks.Application.Commands.SaveTask;
+using SFA.DAS.Tasks.API.Types.Enums;
+
+namespace SFA.DAS.Tasks.Worker.MessageProcessors
+{
+    [TopicSubscription("Task_LegalEntityRemovedProcessor")]
+    public class LegalEntityRemovedMessageProcessor : MessageProcessor<LegalEntityRemovedMessage>
+    {
+        private readonly ILog _logger;
+        private readonly IMediator _mediator;
+
+        public LegalEntityRemovedMessageProcessor(IMessageSubscriberFactory subscriberFactory, ILog logger, IMediator mediator) : base(subscriberFactory, logger)
+        {
+            _logger = logger;
+            _mediator = mediator;
+        }
+
+        protected override async Task ProcessMessage(LegalEntityRemovedMessage message)
+        {
+            _logger.Debug($"Legal entity is being removed (ID:{message?.LegalEntityId})");
+
+            if (message?.AgreementSigned != null && !message.AgreementSigned)
+            {
+                _logger.Debug("Legal entity's agreement task is also being removed as it is incomplete");
+                await _mediator.SendAsync(new SaveTaskCommand
+                {
+                    OwnerId = message.AccountId.ToString(),
+                    Type = TaskType.AgreementToSign,
+                    TaskCompleted = true
+                });
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.Tasks.Worker/SFA.DAS.Tasks.Worker.csproj
+++ b/src/SFA.DAS.Tasks.Worker/SFA.DAS.Tasks.Worker.csproj
@@ -115,6 +115,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DependencyResolution\DefaultRegistry.cs" />
+    <Compile Include="MessageProcessors\LegalEntityRemovedMessageProcessor.cs" />
     <Compile Include="MessageProcessors\SignedEmployerAgreementMessageProcessor.cs" />
     <Compile Include="MessageProcessors\CreatedEmployerAgreementMessageProcessor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
- This fixes the gap on the sign agreement tasks where a organisation is removed before the related agreement is signed and the task counter is not decremented