### PR TITLE
CON-943 Added ApplicableToApprenticeshipEmployerType column

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 
 ## Developer setup
 ### Requirements
-Azure storage account or Azure storage emulator
+- Visual Studio
+- Azure storage account or Azure storage emulator
 
 ### Setup local environment
+- Open the solution in Visual Studio `admin` mode
 - Set SFA.DAS.Tasks.CloudService as the startup project
 - Update ConfigurationSettings in [ServiceConfiguration.Local.cscfg](src/SFA.DAS.Tasks.CloudService.API)
   ```
@@ -25,6 +27,6 @@ Azure storage account or Azure storage emulator
       <Setting name="idaAudience" value="https://citizenazuresfabisgov.onmicrosoft.com/tasks-api" />
     </ConfigurationSettings>
   ```
-- Disable Diagnostics on API and Worker Roles under the CloudService. Expand `Roles` folder in Visual Studio or directly edit `diagnostics.wadcfgx`
+- Disable Diagnostics on API and Worker Roles under the CloudService. Expand `Roles` folder in Visual Studio or directly edit `diagnostics.wadcfgx`for both the roles. 
 
-_If you have issues starting on port 443 make sure that the certificates are installed and no other process is running on 443. I found Cosmos emulator uses port 443, this is not required so can be turned off_
+_If you have issues starting on port 443 make sure that the certificates are installed and no other process is running on 443. I found Cosmos emulator uses port 443, this is not required so can be turned off._

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# das-tasks
+# Digital Apprenticeships Service
+## das-tasks
+|               |               |
+| ------------- | ------------- |
+|![crest](https://assets.publishing.service.gov.uk/government/assets/crests/org_crest_27px-916806dcf065e7273830577de490d5c7c42f36ddec83e907efe62086785f24fb.png)|Tasks|
+| Build | [![Build Status](https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_apis/build/status/Manage%20Apprenticeships/das-tasks?branchName=master)](https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_build/latest?definitionId=540&branchName=master) |
+
+## Developer setup
+### Requirements
+Azure storage account or Azure storage emulator
+
+### Setup local environment
+- Set SFA.DAS.Tasks.CloudService as the startup project
+- Update ConfigurationSettings in [ServiceConfiguration.Local.cscfg](src/SFA.DAS.Tasks.CloudService.API)
+  ```
+    <ConfigurationSettings>
+      <Setting name="EnvironmentName" value="LOCAL" />
+      <Setting name="ConfigurationStorageConnectionString" value="UseDevelopmentStorage=true" />
+      <Setting name="StorageConnectionString" value="UseDevelopmentStorage=true" />
+      <Setting name="LogLevel" value="Debug" />
+      <Setting name="LoggingRedisConnectionString" value="" />
+      <Setting name="LoggingRedisKey" value="" />
+      <Setting name="InstrumentationKey" value=""/>
+      <Setting name="idaTenant" value="citizenazuresfabisgov.onmicrosoft.com" />
+      <Setting name="idaAudience" value="https://citizenazuresfabisgov.onmicrosoft.com/tasks-api" />
+    </ConfigurationSettings>
+  ```
+- Disable Diagnostics on API and Worker Roles under the CloudService. Expand `Roles` folder in Visual Studio or directly edit `diagnostics.wadcfgx`
+
+_If you have issues starting on port 443 make sure that the certificates are installed and no other process is running on 443. I found Cosmos emulator uses port 443, this is not required so can be turned off_

--- a/src/SFA.DAS.Tasks.API.Client/ITaskAPIClient.cs
+++ b/src/SFA.DAS.Tasks.API.Client/ITaskAPIClient.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using SFA.DAS.Tasks.API.Types.DTOs;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.API.Client
 {
     public interface ITaskApiClient
     {
-        Task<IEnumerable<TaskDto>> GetTasks(string employerAccountId, string userid);
+        Task<IEnumerable<TaskDto>> GetTasks(string employerAccountId, string userid, ApprenticeshipEmployerType applicableToApprenticeshipEmployerType);
 
         Task AddUserReminderSupression(string employerAccountId, string userId, string taskType);
     }

--- a/src/SFA.DAS.Tasks.API.Client/TaskApiClient.cs
+++ b/src/SFA.DAS.Tasks.API.Client/TaskApiClient.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using SFA.DAS.NLog.Logger;
 using SFA.DAS.Tasks.API.Types.DTOs;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.API.Client
 {
@@ -20,10 +21,10 @@ namespace SFA.DAS.Tasks.API.Client
             _httpClient = new SecureHttpClient(configuration);
         }
 
-        public async Task<IEnumerable<TaskDto>> GetTasks(string employerAccountId, string userId)
+        public async Task<IEnumerable<TaskDto>> GetTasks(string employerAccountId, string userId, ApprenticeshipEmployerType applicableToApprenticeshipEmployerType)
         {
             var baseUrl = GetBaseUrl();
-            var url = $"{baseUrl}api/tasks/{employerAccountId}/{userId}";
+            var url = $"{baseUrl}api/tasks/{employerAccountId}/{userId}?{nameof(applicableToApprenticeshipEmployerType)}={(int)applicableToApprenticeshipEmployerType}";
 
             _logger.Info($"Get: {url}");
             var json = await _httpClient.GetAsync(url);

--- a/src/SFA.DAS.Tasks.API.Client/TaskApiClient.cs
+++ b/src/SFA.DAS.Tasks.API.Client/TaskApiClient.cs
@@ -21,7 +21,7 @@ namespace SFA.DAS.Tasks.API.Client
             _httpClient = new SecureHttpClient(configuration);
         }
 
-        public async Task<IEnumerable<TaskDto>> GetTasks(string employerAccountId, string userId, ApprenticeshipEmployerType applicableToApprenticeshipEmployerType)
+        public async Task<IEnumerable<TaskDto>> GetTasks(string employerAccountId, string userId, ApprenticeshipEmployerType applicableToApprenticeshipEmployerType = ApprenticeshipEmployerType.All)
         {
             var baseUrl = GetBaseUrl();
             var url = $"{baseUrl}api/tasks/{employerAccountId}/{userId}?{nameof(applicableToApprenticeshipEmployerType)}={(int)applicableToApprenticeshipEmployerType}";

--- a/src/SFA.DAS.Tasks.API.Types/Enums/ApprenticeshipEmployerType.cs
+++ b/src/SFA.DAS.Tasks.API.Types/Enums/ApprenticeshipEmployerType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace SFA.DAS.Tasks.API.Types.Enums
+{
+    [Flags]
+    public enum ApprenticeshipEmployerType
+    {
+        None = 0,
+        Levy = 1,
+        NonLevy = 1 << 1,
+        All = ~None
+    }
+}

--- a/src/SFA.DAS.Tasks.API.Types/SFA.DAS.Tasks.API.Types.csproj
+++ b/src/SFA.DAS.Tasks.API.Types/SFA.DAS.Tasks.API.Types.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DTOs\TaskDto.cs" />
+    <Compile Include="Enums\ApprenticeshipEmployerType.cs" />
     <Compile Include="Enums\TaskType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/SFA.DAS.Tasks.API/Controllers/TaskController.cs
+++ b/src/SFA.DAS.Tasks.API/Controllers/TaskController.cs
@@ -8,6 +8,7 @@ using SFA.DAS.Tasks.Application.Commands.SaveUserReminderSuppression;
 using SFA.DAS.Tasks.Application.Queries.GetTasksByEmployerAccountId;
 using SFA.DAS.Tasks.API.Attributes;
 using SFA.DAS.Tasks.API.Types.DTOs;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.API.Controllers
 {
@@ -30,20 +31,21 @@ namespace SFA.DAS.Tasks.API.Controllers
         public async Task<IHttpActionResult> GetTasks(string employerAccountId)
         {
             //This method is here to support clients that are older than the current breaking change
-            return await GetUserTasks(employerAccountId, string.Empty);
+            return await GetUserTasks(employerAccountId, string.Empty, ApprenticeshipEmployerType.All);
         }
 
         [Route("{userId}", Name = "GetUserTasks")]
         [ApiAuthorize(Roles = "ReadOwnerTasks")]
         [HttpGet]
-        public async Task<IHttpActionResult> GetUserTasks(string employerAccountId, string userId)
+        public async Task<IHttpActionResult> GetUserTasks(string employerAccountId, string userId, ApprenticeshipEmployerType apprenticeshipEmployerType)
         {
             _logger.Debug($"Getting tasks for employer account {employerAccountId}");
 
             var result = await _mediator.SendAsync(new GetTasksByEmployerAccountIdRequest
             {
                 EmployerAccountId = employerAccountId,
-                UserId = userId
+                UserId = userId,
+                ApplicableToApprenticeshipEmployerType = apprenticeshipEmployerType
             });
 
             if (result?.Tasks == null)

--- a/src/SFA.DAS.Tasks.API/Controllers/TaskController.cs
+++ b/src/SFA.DAS.Tasks.API/Controllers/TaskController.cs
@@ -37,7 +37,7 @@ namespace SFA.DAS.Tasks.API.Controllers
         [Route("{userId}", Name = "GetUserTasks")]
         [ApiAuthorize(Roles = "ReadOwnerTasks")]
         [HttpGet]
-        public async Task<IHttpActionResult> GetUserTasks(string employerAccountId, string userId, ApprenticeshipEmployerType apprenticeshipEmployerType)
+        public async Task<IHttpActionResult> GetUserTasks(string employerAccountId, string userId, ApprenticeshipEmployerType applicableToApprenticeshipEmployerType)
         {
             _logger.Debug($"Getting tasks for employer account {employerAccountId}");
 
@@ -45,7 +45,7 @@ namespace SFA.DAS.Tasks.API.Controllers
             {
                 EmployerAccountId = employerAccountId,
                 UserId = userId,
-                ApplicableToApprenticeshipEmployerType = apprenticeshipEmployerType
+                ApplicableToApprenticeshipEmployerType = applicableToApprenticeshipEmployerType
             });
 
             if (result?.Tasks == null)

--- a/src/SFA.DAS.Tasks.Application.UnitTests/Queries/GetTasksByEmployerAccountIdTests/WhenIGetTasks.cs
+++ b/src/SFA.DAS.Tasks.Application.UnitTests/Queries/GetTasksByEmployerAccountIdTests/WhenIGetTasks.cs
@@ -46,7 +46,7 @@ namespace SFA.DAS.Tasks.Application.UnitTests.Queries.GetTasksByEmployerAccountI
 
             _repository = new Mock<ITaskRepository>();
             _repository.Setup(x => x.GetTasks(It.IsAny<string>())).ReturnsAsync(_tasks);
-            _repository.Setup(x => x.GetMonthlyReminderTasks(It.IsAny<string>())).ReturnsAsync(_monthlyRemindertasks);
+            _repository.Setup(x => x.GetMonthlyReminderTasks(It.IsAny<string>(), It.IsAny<ApprenticeshipEmployerType>())).ReturnsAsync(_monthlyRemindertasks);
             _repository.Setup(x => x.GetUserTaskSuppressions(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(new List<TaskType>());
 
             RequestHandler = new GetTasksByEmployerAccountIdHandler(_repository.Object, RequestValidator.Object);
@@ -64,7 +64,7 @@ namespace SFA.DAS.Tasks.Application.UnitTests.Queries.GetTasksByEmployerAccountI
 
             //Assert
             _repository.Verify(x => x.GetTasks(TaskEmployerAccountId), Times.Once);
-            _repository.Verify(x => x.GetMonthlyReminderTasks(TaskEmployerAccountId), Times.Once);
+            _repository.Verify(x => x.GetMonthlyReminderTasks(TaskEmployerAccountId, It.IsAny<ApprenticeshipEmployerType>()), Times.Once);
             Assert.AreEqual(expectedTasks, result.Tasks);
         }
 

--- a/src/SFA.DAS.Tasks.Application/Queries/GetTasksByEmployerAccountId/GetTasksByEmployerAccountIdHandler.cs
+++ b/src/SFA.DAS.Tasks.Application/Queries/GetTasksByEmployerAccountId/GetTasksByEmployerAccountIdHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using MediatR;
+using SFA.DAS.Tasks.API.Types.Enums;
 using SFA.DAS.Tasks.Application.Exceptions;
 using SFA.DAS.Tasks.Application.Validation;
 using SFA.DAS.Tasks.Domain.Repositories;
@@ -29,7 +30,7 @@ namespace SFA.DAS.Tasks.Application.Queries.GetTasksByEmployerAccountId
 
             var tasks = await _repository.GetTasks(message.EmployerAccountId);
 
-            var monthlyReminderTasks = await _repository.GetMonthlyReminderTasks(message.EmployerAccountId);
+            var monthlyReminderTasks = await _repository.GetMonthlyReminderTasks(message.EmployerAccountId, message.ApplicableToApprenticeshipEmployerType);
 
             if (!string.IsNullOrEmpty(message.UserId))
             {

--- a/src/SFA.DAS.Tasks.Application/Queries/GetTasksByEmployerAccountId/GetTasksByEmployerAccountIdRequest.cs
+++ b/src/SFA.DAS.Tasks.Application/Queries/GetTasksByEmployerAccountId/GetTasksByEmployerAccountIdRequest.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using SFA.DAS.Tasks.API.Types.Enums;
 
 namespace SFA.DAS.Tasks.Application.Queries.GetTasksByEmployerAccountId
 {
@@ -6,5 +7,6 @@ namespace SFA.DAS.Tasks.Application.Queries.GetTasksByEmployerAccountId
     {
         public string EmployerAccountId { get; set; }
         public string UserId { get; set; }
+        public ApprenticeshipEmployerType ApplicableToApprenticeshipEmployerType { get; set; }
     }
 }

--- a/src/SFA.DAS.Tasks.DataAccess/Repositories/TaskRepository.cs
+++ b/src/SFA.DAS.Tasks.DataAccess/Repositories/TaskRepository.cs
@@ -47,12 +47,15 @@ namespace SFA.DAS.Tasks.DataAccess.Repositories
             });
         }
 
-        public async Task<IEnumerable<DasTask>> GetMonthlyReminderTasks(string employerAccountId)
+        public async Task<IEnumerable<DasTask>> GetMonthlyReminderTasks(string employerAccountId, ApprenticeshipEmployerType apprenticeshipEmployerTypes)
         {
             return await WithConnection(async c =>
             {
+                var parameters = new DynamicParameters();
+                parameters.Add("@applicableToApprenticeshipEmployerType", apprenticeshipEmployerTypes, DbType.Int32);
                 var tasks = (await c.QueryAsync<DasTask>(
                     sql: "[tasks].[GetMonthlyReminderTasks]",
+                    param: parameters,
                     commandType: CommandType.StoredProcedure)).ToList();
 
                 foreach (var task in tasks)

--- a/src/SFA.DAS.Tasks.Database/Post-Deployment/Script.PostDeployment1.sql
+++ b/src/SFA.DAS.Tasks.Database/Post-Deployment/Script.PostDeployment1.sql
@@ -14,8 +14,15 @@ Post-Deployment Script Template
 -- Populate monthly Employer Acccounts Reminder Tasks table --
 ------------------------------------------------
 
-if(not exists(select top 1 * from [Tasks].[MonthlyReminderTasks] WHERE [Type] = 'LevyDeclarationDue'))
-begin
-	INSERT INTO [Tasks].[MonthlyReminderTasks] (Id, Type, StartDay, EndDay) 
-	VALUES (NEWID(), 'LevyDeclarationDue', 16, 19)
-end
+MERGE [Tasks].[MonthlyReminderTasks] AS target
+USING (SELECT NEWID(), 'LevyDeclarationDue', 16, 19, 1) 
+	AS source (Id, Type, StartDay, EndDay, ApplicableToApprenticeshipEmployerType)
+ON (target.Type = source.Type)
+WHEN MATCHED THEN
+	UPDATE SET 
+		StartDay = source.StartDay,
+		EndDay = source.EndDay,
+		ApplicableToApprenticeshipEmployerType = source.ApplicableToApprenticeshipEmployerType
+WHEN NOT MATCHED THEN 
+	INSERT (Id, Type, StartDay, EndDay, ApplicableToApprenticeshipEmployerType)
+	VALUES (source.Id, source.Type, source.StartDay, source.EndDay, source.ApplicableToApprenticeshipEmployerType);

--- a/src/SFA.DAS.Tasks.Database/StoredProcedures/GetMonthlyReminderTasks.sql
+++ b/src/SFA.DAS.Tasks.Database/StoredProcedures/GetMonthlyReminderTasks.sql
@@ -1,6 +1,7 @@
-﻿CREATE PROCEDURE [Tasks].[GetMonthlyReminderTasks]	
+﻿CREATE PROCEDURE [Tasks].[GetMonthlyReminderTasks]
+	@applicableToApprenticeshipEmployerType smallint
 AS
 	SELECT * FROM [Tasks].[MonthlyReminderTasks] 
-	WHERE StartDay <= DAY(GETDATE()) AND
-	EndDay >= DAY(GETDATE())
-
+	WHERE StartDay <= DAY(GETDATE()) 
+	AND EndDay >= DAY(GETDATE())
+	AND @applicableToApprenticeshipEmployerType & ApplicableToApprenticeshipEmployerType <> 0 

--- a/src/SFA.DAS.Tasks.Database/Tables/MonthlyReminderTasks.sql
+++ b/src/SFA.DAS.Tasks.Database/Tables/MonthlyReminderTasks.sql
@@ -3,5 +3,6 @@
 	[Id] UNIQUEIDENTIFIER NOT NULL PRIMARY KEY, 
     [Type] VARCHAR(100) NOT NULL, 
 	[StartDay] TINYINT NOT NULL,  -- Day of the month to start showing task
-	[EndDay] TINYINT NOT NULL     -- Day of the month to stop showing task
+	[EndDay] TINYINT NOT NULL,     -- Day of the month to stop showing task
+	[ApplicableToApprenticeshipEmployerType] SMALLINT NOT NULL DEFAULT (-1)
 )

--- a/src/SFA.DAS.Tasks.Domain/Models/DasTask.cs
+++ b/src/SFA.DAS.Tasks.Domain/Models/DasTask.cs
@@ -9,5 +9,6 @@ namespace SFA.DAS.Tasks.Domain.Models
         public TaskType Type { get; set; }
         public string EmployerAccountId { get; set; }
         public ushort ItemsDueCount { get; set; }
+        public ApprenticeshipEmployerType ApplicableToApprenticeshipEmployerType { get; set; }
     }
 }

--- a/src/SFA.DAS.Tasks.Domain/Repositories/ITaskRepository.cs
+++ b/src/SFA.DAS.Tasks.Domain/Repositories/ITaskRepository.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.Tasks.Domain.Repositories
 
         Task<DasTask> GetTask(string employerAccountId, TaskType type);
 
-        Task<IEnumerable<DasTask>> GetMonthlyReminderTasks(string employerAccountId);
+        Task<IEnumerable<DasTask>> GetMonthlyReminderTasks(string employerAccountId, ApprenticeshipEmployerType apprenticeshipEmployerTypes);
 
         Task SaveUserReminderSuppression(UserReminderSuppressionFlag flag);
 


### PR DESCRIPTION
- The new column is introduced in MonthlyReminderTask to distinguish if the task is applicable to employers of type Levy, Non-levy or both. Hence the column name is preceded with "ApplicableTo". 
- The column will hold multiple values as a bit integer. The default value is "-1" which means applicable to all.  
- The `LevyDeclarationDue` data feed was changed to update it with new column set to `1` which indicates Levy only. 
- The ApprenticeshipEmployerType enum is using Flags to allow querying for multiple types. 
- Stored procedure retrieving MonthlyReminderTask is updated to filter on the requested employer type, this is per Mike's suggestion. 
